### PR TITLE
Add backend repository link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Zeroclaw
+
+## Backend Repository
+
+The backend service for this project is hosted at:
+
+- https://github.com/yourname/openclaw-backend
+
+You can clone it locally with:
+
+```bash
+git clone https://github.com/yourname/openclaw-backend.git
+```


### PR DESCRIPTION
### Motivation
- Document the location of the backend service and provide a quick clone instruction for contributors.

### Description
- Add a new `README.md` containing a "Backend Repository" section linking to `https://github.com/yourname/openclaw-backend` and showing the `git clone` command.

### Testing
- Verified the new file contents with `nl -ba README.md` and checked repository status with `git status --short`, both showing the README was added successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0177831dc832ab83e994d01122e26)